### PR TITLE
Allow event service provider to map interfaces

### DIFF
--- a/src/EventServiceProviderTrait.php
+++ b/src/EventServiceProviderTrait.php
@@ -18,6 +18,7 @@ use ReflectionClass;
  * This is the event service provider trait.
  *
  * @author Graham Campbell <graham@alt-three.com>
+ * @author James Brooks <james@alt-three.com>
  */
 trait EventServiceProviderTrait
 {
@@ -52,13 +53,7 @@ trait EventServiceProviderTrait
         $map = $this->getListenerMap();
 
         foreach (array_keys($map) as $event) {
-            $reflection = new ReflectionClass($event);
-
-            if ($reflection->isInterface()) {
-                $this->assertTrue(interface_exists($event));
-            } else {
-                $this->assertTrue(class_exists($event));
-            }
+             $this->assertTrue(class_exists($event) || interface_exists($event));
         }
     }
 

--- a/src/EventServiceProviderTrait.php
+++ b/src/EventServiceProviderTrait.php
@@ -53,7 +53,7 @@ trait EventServiceProviderTrait
         $map = $this->getListenerMap();
 
         foreach (array_keys($map) as $event) {
-             $this->assertTrue(class_exists($event) || interface_exists($event));
+            $this->assertTrue(class_exists($event) || interface_exists($event));
         }
     }
 

--- a/src/EventServiceProviderTrait.php
+++ b/src/EventServiceProviderTrait.php
@@ -52,7 +52,13 @@ trait EventServiceProviderTrait
         $map = $this->getListenerMap();
 
         foreach (array_keys($map) as $event) {
-            $this->assertTrue(class_exists($event));
+            $reflection = new ReflectionClass($event);
+
+            if ($reflection->isInterface()) {
+                $this->assertTrue(interface_exists($event));
+            } else {
+                $this->assertTrue(class_exists($event));
+            }
         }
     }
 


### PR DESCRIPTION
Since @GrahamCampbell added this to Laravel 5.3, TestBench should support it.