### PR TITLE
removed '\\Foundations' in Namespaces

### DIFF
--- a/src/EventTrait.php
+++ b/src/EventTrait.php
@@ -48,7 +48,7 @@ trait EventTrait
     {
         $split = explode('\\', (new ReflectionClass($this))->getName());
 
-        return "{$split[0]}\\{$split[2]}\\Foundation\\Providers\\EventServiceProvider";
+        return "{$split[0]}\\{$split[2]}\\Providers\\EventServiceProvider";
     }
 
     public function testEventImplementsTheCorrectInterfaces()

--- a/src/ServiceProviderTrait.php
+++ b/src/ServiceProviderTrait.php
@@ -32,6 +32,6 @@ trait ServiceProviderTrait
         $split = explode('\\', (new ReflectionClass($this))->getName());
         $class = substr(end($split), 0, -4);
 
-        return "{$split[0]}\\{$split[2]}\\Foundation\\Providers\\{$class}";
+        return "{$split[0]}\\{$split[2]}\\Providers\\{$class}";
     }
 }


### PR DESCRIPTION
Changed Namespaces that made Cachet/2.4 Unit Tests fail