### PR TITLE
[BREAKING] Remove "Foundation" from service provider Namespace

### DIFF
--- a/src/EventTrait.php
+++ b/src/EventTrait.php
@@ -48,7 +48,7 @@ trait EventTrait
     {
         $split = explode('\\', (new ReflectionClass($this))->getName());
 
-        return "{$split[0]}\\{$split[2]}\\Foundation\\Providers\\EventServiceProvider";
+        return "{$split[0]}\\{$split[2]}\\Providers\\EventServiceProvider";
     }
 
     public function testEventImplementsTheCorrectInterfaces()

--- a/src/ServiceProviderTrait.php
+++ b/src/ServiceProviderTrait.php
@@ -32,6 +32,6 @@ trait ServiceProviderTrait
         $split = explode('\\', (new ReflectionClass($this))->getName());
         $class = substr(end($split), 0, -4);
 
-        return "{$split[0]}\\{$split[2]}\\Foundation\\Providers\\{$class}";
+        return "{$split[0]}\\{$split[2]}\\Providers\\{$class}";
     }
 }


### PR DESCRIPTION
Help the layout of any dependent projects stick to normal Laravel
structure, e.g. https://github.com/CachetHQ/Cachet/pull/4071

Ideally this should get merged into a new branch `5.0` and released as a v5 as it's quite a breaking change.